### PR TITLE
feat: add donor lamports verification for campaign donations

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -9,12 +9,7 @@
   <component name="ChangeListManager">
     <list default="true" id="6c6e0892-4ab3-4c4b-a7e4-46abe13189f9" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/instruction.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/instruction.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/modules/create_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/create_campaign.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/modules/donate_to_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/donate_to_campaign.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/modules/withdraw_from_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/withdraw_from_campaign.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/state.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/state.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/tests/tests.rs" beforeDir="false" afterPath="$PROJECT_DIR$/tests/tests.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -86,7 +81,7 @@
     "RunOnceActivity.CodyProjectSettingsMigration": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.rust.reset.selective.auto.import": "true",
-    "git-widget-placeholder": "refactor/error-handling",
+    "git-widget-placeholder": "feature/verify-donor-lamports",
     "last_opened_file_path": "/Users/admin/Documents/Development/Rust/sol_crowdfunding",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",

--- a/src/modules/donate_to_campaign.rs
+++ b/src/modules/donate_to_campaign.rs
@@ -32,6 +32,12 @@ pub fn donate_to_campaign(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
+    // verify donor has enough lamports to donate
+    if donation_account.lamports() < amount {
+        msg!("Donor does not have enough lamports to donate");
+        return Err(ProgramError::InsufficientFunds);
+    }
+
     let mut donation_state = DonationState::try_from_slice(&donation_account.data.borrow())
         .map_err(|err| {
             msg!("Error deserializing DonationState: {}", err);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -51,7 +51,7 @@ async fn crowdfunding_program_test() -> Result<(), TransportError> {
     program_test.add_account(
         donation_keypair.pubkey(),
         Account {
-            lamports: 1_000_000_000_000,
+            lamports: 10_000_000_000,
             data: vec![0; donation_account_size],
             owner: program_id,
             ..Account::default()
@@ -94,7 +94,7 @@ async fn crowdfunding_program_test() -> Result<(), TransportError> {
         &ProgramInstruction::DonateFunds {
             campaign: campaign_keypair.pubkey(),
             donor: donation_keypair.pubkey(),
-            amount: 20_000_000_000,
+            amount: 5_000_000_000,
         },
         vec![
             AccountMeta::new(campaign_keypair.pubkey(), false),


### PR DESCRIPTION
**Context**
- This PR introduces a verification step to ensure donors have sufficient lamports in their accounts before donating to campaigns.
- The functionality checks the donor's balance against the required donation amount, preventing transactions if the donor has insufficient funds.
- This change is crucial for maintaining the integrity of the donation process and ensuring that only valid contributions are processed.

**Changes**
- Added a conditional statement to verify the donor have sufficient lamports.