### PR TITLE
feat: implement validation for campaign account key

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -10,7 +10,6 @@
     <list default="true" id="6c6e0892-4ab3-4c4b-a7e4-46abe13189f9" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/modules/donate_to_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/donate_to_campaign.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/tests.rs" beforeDir="false" afterPath="$PROJECT_DIR$/tests/tests.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -81,7 +80,7 @@
     "RunOnceActivity.CodyProjectSettingsMigration": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.rust.reset.selective.auto.import": "true",
-    "git-widget-placeholder": "feature/verify-donor-lamports",
+    "git-widget-placeholder": "feature/validate-campaign-account",
     "last_opened_file_path": "/Users/admin/Documents/Development/Rust/sol_crowdfunding",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",

--- a/src/modules/donate_to_campaign.rs
+++ b/src/modules/donate_to_campaign.rs
@@ -38,6 +38,12 @@ pub fn donate_to_campaign(
         return Err(ProgramError::InsufficientFunds);
     }
 
+    // validate campaign argument matches account key
+    if campaign != *campaign_account.key {
+        msg!("Campaign argument does not match account key");
+        return Err(ProgramError::InvalidArgument);
+    }
+
     let mut donation_state = DonationState::try_from_slice(&donation_account.data.borrow())
         .map_err(|err| {
             msg!("Error deserializing DonationState: {}", err);


### PR DESCRIPTION
**Context**
- This PR introduces a validation to ensure the campaign is valid before allowing the donor to make donations to it.
- The functionality checks the `campaign` argument against the campaign account's key, preventing transactions if they are not a match.

**Changes**
- Added conditions to ensure the argument and the account's key are identical.