### PR TITLE
feat: add withdrawal account ownership verification

### DIFF
--- a/.idea/cody_history.xml
+++ b/.idea/cody_history.xml
@@ -31,6 +31,12 @@
               <chat>
                 <internalId value="319292dc-1f69-4642-95d5-2361d182c54d" />
               </chat>
+              <chat>
+                <internalId value="e0b2189c-804a-49f9-a9db-14021c171348" />
+              </chat>
+              <chat>
+                <internalId value="65d9be19-472b-4157-beb1-348b96ac33e5" />
+              </chat>
             </list>
           </chats>
         </AccountData>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -8,8 +8,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6c6e0892-4ab3-4c4b-a7e4-46abe13189f9" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/cody_history.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/cody_history.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/modules/create_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/create_campaign.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/modules/donate_to_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/donate_to_campaign.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/modules/withdraw_from_campaign.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/modules/withdraw_from_campaign.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/tests.rs" beforeDir="false" afterPath="$PROJECT_DIR$/tests/tests.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -80,7 +84,7 @@
     "RunOnceActivity.CodyProjectSettingsMigration": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.rust.reset.selective.auto.import": "true",
-    "git-widget-placeholder": "feature/validate-campaign-account",
+    "git-widget-placeholder": "feature/verify-account-ownership",
     "last_opened_file_path": "/Users/admin/Documents/Development/Rust/sol_crowdfunding",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
@@ -233,6 +237,7 @@
       <workItem from="1727076400632" duration="5054000" />
       <workItem from="1727086233418" duration="10770000" />
       <workItem from="1727154944595" duration="2646000" />
+      <workItem from="1727887251097" duration="4952000" />
     </task>
     <servers />
   </component>

--- a/src/modules/create_campaign.rs
+++ b/src/modules/create_campaign.rs
@@ -47,7 +47,7 @@ pub fn create_campaign(
     campaign_state
         .serialize(&mut &mut campaign_account.data.borrow_mut()[..])
         .map_err(|err| {
-            msg!("Error serializing campaign account: {}", err);
+            msg!("Error serializing CampaignState: {}", err);
             ProgramError::InvalidAccountData
         })?;
 

--- a/src/modules/donate_to_campaign.rs
+++ b/src/modules/donate_to_campaign.rs
@@ -32,13 +32,13 @@ pub fn donate_to_campaign(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // verify donor has enough lamports to donate
+    // Verify donor has enough lamports to donate
     if donation_account.lamports() < amount {
         msg!("Donor does not have enough lamports to donate");
         return Err(ProgramError::InsufficientFunds);
     }
 
-    // validate campaign argument matches account key
+    // Validate campaign argument matches account key
     if campaign != *campaign_account.key {
         msg!("Campaign argument does not match account key");
         return Err(ProgramError::InvalidArgument);
@@ -50,7 +50,7 @@ pub fn donate_to_campaign(
             ProgramError::InvalidAccountData
         })?;
 
-    // update the donation state with the new data
+    // Update the donation state with the new data
     donation_state.amount = amount;
     donation_state.campaign = campaign;
     donation_state.donor = donor;
@@ -60,7 +60,7 @@ pub fn donate_to_campaign(
     **donation_account.try_borrow_mut_lamports()? -= donation_amount;
     **campaign_account.try_borrow_mut_lamports()? += donation_amount;
 
-    // serialize the updated state back into the donation account
+    // Serialize the updated state back into the donation account
     donation_state
         .serialize(&mut &mut donation_account.data.borrow_mut()[..])
         .map_err(|err| {
@@ -68,24 +68,26 @@ pub fn donate_to_campaign(
             ProgramError::InvalidAccountData
         })?;
 
-    // update the campaign state with donation amount
+    // Update the campaign state with donation amount
     let mut campaign_state = CampaignState::try_from_slice(&campaign_account.data.borrow())
         .map_err(|err| {
             msg!("Error deserializing CampaignState: {}", err);
             ProgramError::InvalidAccountData
         })?;
+
     campaign_state.amount_raised += donation_amount;
     campaign_state
         .serialize(&mut &mut campaign_account.data.borrow_mut()[..])
         .map_err(|err| {
-            msg!("Error serializing campaign account: {}", err);
+            msg!("Error serializing CampaignState: {}", err);
             ProgramError::InvalidAccountData
         })?;
 
     msg!(
-        "✅ Donated {} SOL ({} Lamports) to {}",
+        "✅ Donated {} SOL ({} Lamports) from {} to {}",
         lamports_to_sol(donation_amount),
         donation_amount,
+        donation_account.key,
         campaign_account.key
     );
 

--- a/src/modules/withdraw_from_campaign.rs
+++ b/src/modules/withdraw_from_campaign.rs
@@ -4,7 +4,7 @@ use solana_program::{
     native_token::lamports_to_sol, program_error::ProgramError, pubkey::Pubkey,
 };
 
-use crate::state::WithdrawState;
+use crate::state::{CampaignState, WithdrawState};
 
 pub fn withdraw_from_campaign(
     program_id: &Pubkey,
@@ -17,29 +17,36 @@ pub fn withdraw_from_campaign(
     let account_info_iter = &mut accounts.iter();
 
     let campaign_account = next_account_info(account_info_iter)?;
-    let withdrawal_account = next_account_info(account_info_iter)?;
+    let creator_account = next_account_info(account_info_iter)?;
 
     if campaign_account.owner != program_id {
         msg!("Campaign account must be owned by the program");
         return Err(ProgramError::IncorrectProgramId);
     }
 
-    if !campaign_account.is_writable {
-        msg!("Campaign account must be writable");
+    if !campaign_account.is_writable || !creator_account.is_writable {
+        msg!("Both accounts must be writable");
         return Err(ProgramError::InvalidAccountData);
     }
 
-    if !withdrawal_account.is_signer {
-        msg!("Withdrawal account must sign the transaction");
+    if !creator_account.is_signer {
+        msg!("Creator account must sign the transaction");
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    if !withdrawal_account.is_writable {
-        msg!("Withdrawal account must be writable");
+    let campaign_state = CampaignState::try_from_slice(&campaign_account.data.borrow())
+        .map_err(|err| {
+            msg!("Error deserializing CampaignState: {}", err);
+            ProgramError::InvalidAccountData
+        })?;
+
+    // Verify that the withdrawal account is actually the creator of the campaign
+    if campaign_state.creator != *creator_account.key {
+        msg!("Only the campaign creator can withdraw funds");
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut withdrawal_state = WithdrawState::try_from_slice(&withdrawal_account.data.borrow())
+    let mut withdrawal_state = WithdrawState::try_from_slice(&creator_account.data.borrow())
         .map_err(|err| {
             msg!("Error deserializing WithdrawState: {}", err);
             ProgramError::InvalidAccountData
@@ -50,11 +57,6 @@ pub fn withdraw_from_campaign(
     withdrawal_state.creator = creator;
     withdrawal_state.recipient = recipient;
 
-    if withdrawal_state.creator != *withdrawal_account.key {
-        msg!("Only the campaign creator can withdraw funds");
-        return Err(ProgramError::InvalidAccountData);
-    }
-
     let withdrawal_amount = withdrawal_state.amount;
 
     if **campaign_account.lamports.borrow() < withdrawal_amount {
@@ -63,12 +65,12 @@ pub fn withdraw_from_campaign(
     }
 
     **campaign_account.try_borrow_mut_lamports()? -= withdrawal_amount;
-    **withdrawal_account.try_borrow_mut_lamports()? += withdrawal_amount;
+    **creator_account.try_borrow_mut_lamports()? += withdrawal_amount;
 
     withdrawal_state
-        .serialize(&mut &mut withdrawal_account.data.borrow_mut()[..])
+        .serialize(&mut &mut creator_account.data.borrow_mut()[..])
         .map_err(|err| {
-            msg!("Error serializing withdrawal account: {}", err);
+            msg!("Error serializing WithdrawalState: {}", err);
             ProgramError::InvalidAccountData
         })?;
 
@@ -78,7 +80,7 @@ pub fn withdraw_from_campaign(
         withdrawal_amount,
         campaign_account.key,
         withdrawal_state.recipient,
-        withdrawal_account.key,
+        creator_account.key,
     );
 
     Ok(())


### PR DESCRIPTION
**Context**
This PR introduces a feature to verify who the account owner is before a withdrawal can be made. The feature checks the value of the creator field in the withdrawal state against the campaign account's key for verification and prevents the withdrawal if they do not match. This change ensures that only the campaign creator has the right to make withdrawals.

**Changes**
- Added the statement to check if the withdrawal state's creator matches the campaign account's key.
- Renamed the `withdrawal_account` variable to `creator_account` for simplicity and clarification.
- Updated `msg` log in `donate_to_campaign` to include the donor pubkey where the funds are coming from.